### PR TITLE
use empty struct as map value instead of bool

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -10,8 +10,8 @@ type Analyzer struct {
 	SupportedExtensions map[string]string
 	path                string
 	excludePaths        []string
-	excludeExtensions   map[string]bool
-	includeExtensions   map[string]bool
+	excludeExtensions   map[string]struct{}
+	includeExtensions   map[string]struct{}
 }
 
 type FileMetadata struct {
@@ -23,8 +23,8 @@ type FileMetadata struct {
 func NewAnalyzer(
 	path string,
 	excludePaths []string,
-	excludeExtensions map[string]bool,
-	includeExtensions map[string]bool,
+	excludeExtensions map[string]struct{},
+	includeExtensions map[string]struct{},
 	extensions map[string]string,
 ) *Analyzer {
 	return &Analyzer{

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -16,14 +16,14 @@ func TestNewAnalyzer(t *testing.T) {
 		SupportedExtensions: extensions,
 		path:                "test/",
 		excludePaths:        []string{"test"},
-		excludeExtensions:   map[string]bool{".go": true},
-		includeExtensions:   map[string]bool{},
+		excludeExtensions:   map[string]struct{}{".go": {}},
+		includeExtensions:   map[string]struct{}{},
 	}
 	analyser := NewAnalyzer(
 		"test/",
 		[]string{"test"},
-		map[string]bool{".go": true},
-		map[string]bool{},
+		map[string]struct{}{".go": {}},
+		map[string]struct{}{},
 		extensions,
 	)
 	require.NotNil(t, analyser)
@@ -42,8 +42,8 @@ func TestMatchingFiles(t *testing.T) {
 			analyzer: NewAnalyzer(
 				codeSamplesDir,
 				[]string{},
-				map[string]bool{},
-				map[string]bool{},
+				map[string]struct{}{},
+				map[string]struct{}{},
 				extensions,
 			),
 			want: []FileMetadata{
@@ -114,8 +114,8 @@ func TestMatchingFiles(t *testing.T) {
 			analyzer: NewAnalyzer(
 				codeSamplesDir,
 				[]string{filepath.Join(codeSamplesDir, "main.go")},
-				map[string]bool{},
-				map[string]bool{},
+				map[string]struct{}{},
+				map[string]struct{}{},
 				extensions,
 			),
 			want: []FileMetadata{
@@ -181,8 +181,8 @@ func TestMatchingFiles(t *testing.T) {
 			analyzer: NewAnalyzer(
 				codeSamplesDir,
 				[]string{},
-				map[string]bool{".go": true},
-				map[string]bool{},
+				map[string]struct{}{".go": {}},
+				map[string]struct{}{},
 				extensions,
 			),
 			want: []FileMetadata{
@@ -248,8 +248,8 @@ func TestMatchingFiles(t *testing.T) {
 			analyzer: NewAnalyzer(
 				codeSamplesDir,
 				[]string{},
-				map[string]bool{},
-				map[string]bool{".go": true},
+				map[string]struct{}{},
+				map[string]struct{}{".go": {}},
 				extensions,
 			),
 			want: []FileMetadata{

--- a/pkg/gcloc/gcloc_test.go
+++ b/pkg/gcloc/gcloc_test.go
@@ -42,8 +42,8 @@ func TestNewGCloc(t *testing.T) {
 				analyzer: analyzer.NewAnalyzer(
 					filepath.Join(testDir, "fixtures", "code_samples"),
 					nil,
-					map[string]bool{},
-					map[string]bool{},
+					map[string]struct{}{},
+					map[string]struct{}{},
 					getExtensionsMap(constants.Languages),
 				),
 				scanner:   scanner.NewScanner(constants.Languages),
@@ -72,8 +72,8 @@ func TestNewGCloc(t *testing.T) {
 				analyzer: analyzer.NewAnalyzer(
 					filepath.Join(testDir, "fixtures", "code_samples"),
 					nil,
-					map[string]bool{".go": true},
-					map[string]bool{},
+					map[string]struct{}{".go": {}},
+					map[string]struct{}{},
 					getExtensionsMap(constants.Languages),
 				),
 				scanner:   scanner.NewScanner(constants.Languages),
@@ -102,8 +102,8 @@ func TestNewGCloc(t *testing.T) {
 				analyzer: analyzer.NewAnalyzer(
 					filepath.Join(testDir, "fixtures", "code_samples"),
 					nil,
-					map[string]bool{},
-					map[string]bool{},
+					map[string]struct{}{},
+					map[string]struct{}{},
 					getExtensionsMap(constants.Languages),
 				),
 				scanner: scanner.NewScanner(constants.Languages),

--- a/pkg/utils/convert_to_map.go
+++ b/pkg/utils/convert_to_map.go
@@ -1,10 +1,10 @@
 package utils
 
-func ConvertToMap(arr []string) map[string]bool {
-	mp := map[string]bool{}
+func ConvertToMap(arr []string) map[string]struct{} {
+	mp := map[string]struct{}{}
 
 	for _, x := range arr {
-		mp[x] = true
+		mp[x] = struct{}{}
 	}
 
 	return mp

--- a/pkg/utils/convert_to_map_test.go
+++ b/pkg/utils/convert_to_map_test.go
@@ -10,24 +10,24 @@ func TestConvertToMap(t *testing.T) {
 	tests := []struct {
 		name string
 		arr  []string
-		want map[string]bool
+		want map[string]struct{}
 	}{
 		{
 			name: "Should convert array to map",
 			arr:  []string{".go", ".c", ".cpp"},
-			want: map[string]bool{
-				".go":  true,
-				".c":   true,
-				".cpp": true,
+			want: map[string]struct{}{
+				".go":  {},
+				".c":   {},
+				".cpp": {},
 			},
 		},
 		{
 			name: "Should convert array(with repeated values) to map",
 			arr:  []string{".go", ".c", ".c", ".cpp"},
-			want: map[string]bool{
-				".go":  true,
-				".c":   true,
-				".cpp": true,
+			want: map[string]struct{}{
+				".go":  {},
+				".c":   {},
+				".cpp": {},
 			},
 		},
 	}


### PR DESCRIPTION
This is just a minor improvement for Go code.
The map value can be replaced by empty struct `struct{}`, which does not consume any storage.